### PR TITLE
Replace deprecated Bitwise.^^^/2 with Bitwise.bxor/2

### DIFF
--- a/lib/datamatrix/galois_field.ex
+++ b/lib/datamatrix/galois_field.ex
@@ -21,7 +21,7 @@ defmodule DataMatrix.GaloisField do
   @doc """
 
   """
-  def add(a, b), do: a ^^^ b
+  def add(a, b), do: bxor(a, b)
 
   @doc """
 


### PR DESCRIPTION
`Bitwise.^^^/2` has been deprecated in Elixir 1.12.0. 
This PR replaces it with `Bitwise.bxor/2`.